### PR TITLE
Rename Component Options to Attributes

### DIFF
--- a/lib/components/rails/component.rb
+++ b/lib/components/rails/component.rb
@@ -12,20 +12,20 @@ module Components
       include ::AbstractController::Caching
       include Caching
 
-      attr_accessor :object, :view, :options, :response_body
+      attr_accessor :object, :view, :attributes, :response_body
       attr_reader :block_content
-      helper_method :object, :block_content, :options
+      helper_method :object, :block_content, :attributes
 
       delegate :cache, :'output_buffer=', :output_buffer, to: :view
       delegate :cache_store, to: :class
 
-      def initialize(object, view, action, options = {})
+      def initialize(object, view, action, attributes = {})
         @object = object
         @view = view
-        @options = options
+        @attributes = attributes
         @action = action
 
-        @block_content = options[:block].call if options[:block]
+        @block_content = attributes[:block].call if attributes[:block]
       end
 
       def action_name
@@ -46,14 +46,14 @@ module Components
 
       def _process_options(options)
         super.tap do |opts|
-          if self.options[:collection_iteration]
-            opts[:locals] = {collection_iteration: self.options[:collection_iteration]}
+          if attributes[:collection_iteration]
+            opts[:locals] = {collection_iteration: attributes[:collection_iteration]}
           end
         end
       end
 
       def component_name
-        options[:component] || self.class.component_name
+        attributes[:component] || self.class.component_name
       end
 
       def perform_caching
@@ -61,7 +61,7 @@ module Components
       end
 
       def default_template
-        self.class == Components::Rails::Component ? "#{options[:component]}/#{action_name}" : action_name.to_s
+        self.class == Components::Rails::Component ? "#{attributes[:component]}/#{action_name}" : action_name.to_s
       end
 
       def default_render

--- a/spec/components/rails/component_spec.rb
+++ b/spec/components/rails/component_spec.rb
@@ -79,8 +79,8 @@ RSpec.describe Components::Rails::Component do
           expect(described_class._helper_methods).to include(:a_helper)
         end
 
-        it 'makes options available in rendering' do
-          expect(described_class._helper_methods).to include(:options)
+        it 'makes attributes available in rendering' do
+          expect(described_class._helper_methods).to include(:attributes)
         end
       end
 

--- a/spec/features/rendering_spec.rb
+++ b/spec/features/rendering_spec.rb
@@ -6,14 +6,14 @@ RSpec.describe 'rendering' do
   let(:component_class) do
     Class.new(Components::Rails::Component) do
       def cache_key
-        [an_option, block_content]
+        [an_attribute, block_content]
       end
 
       def show
         render inline: <<~eos
           some content
 
-          <%= an_option %>
+          <%= an_attribute %>
 
           more content
         eos
@@ -29,17 +29,17 @@ RSpec.describe 'rendering' do
         eos
       end
 
-      def an_option
-        options[:an_option]
+      def an_attribute
+        attributes[:an_attribute]
       end
-      helper_method :an_option
+      helper_method :an_attribute
     end
   end
 
   before { Object.const_set("My#{Time.now.subsec.numerator}Component", component_class) }
 
   it 'renders a component' do
-    expect(component_class.render_action(:show, ActionView::Base.new, an_option: 'value')).to eq(<<~eos)
+    expect(component_class.render_action(:show, ActionView::Base.new, an_attribute: 'value')).to eq(<<~eos)
       some content
 
       value
@@ -62,7 +62,7 @@ RSpec.describe 'rendering' do
 
   describe 'block_content in #cache_key' do
     subject do
-      component_class.new(nil, ActionView::Base.new, :show, an_option: :value, block: proc { 'the block' })
+      component_class.new(nil, ActionView::Base.new, :show, an_attribute: :value, block: proc { 'the block' })
     end
 
     it 'works' do


### PR DESCRIPTION
Fixes #12 

Note that I am only renaming attributes inside the Component instance, not the class methods for contextual reasons.

