### PR TITLE
Update Caching to Recognize Action and Support Digesting

### DIFF
--- a/lib/components/rails/caching.rb
+++ b/lib/components/rails/caching.rb
@@ -16,11 +16,23 @@ module Components
       end
 
       def cached_render
-        @cached_render ||= read_fragment(cache_key)
+        @cached_render ||= read_fragment(cache_fragment_name)
       end
 
       def cache_render
-        write_fragment(cache_key, response_body)
+        write_fragment(cache_fragment_name, response_body)
+      end
+
+      def cache_fragment_name
+        if digest = ::ActionView::Digestor.digest(name: virtual_path, finder: lookup_context)
+          ["#{virtual_path}:#{digest}", cache_key]
+        else
+          [virtual_path, name]
+        end
+      end
+
+      def virtual_path
+        "#{component_path}/#{action_name}"
       end
     end
   end

--- a/lib/components/rails/component.rb
+++ b/lib/components/rails/component.rb
@@ -67,7 +67,7 @@ module Components
       end
 
       def default_template
-        self.class == Components::Rails::Component ? "#{attributes[:component]}/#{action_name}" : action_name.to_s
+        self.class == Components::Rails::Component ? "#{component_path}/#{action_name}" : action_name.to_s
       end
 
       def default_render

--- a/lib/components/rails/component.rb
+++ b/lib/components/rails/component.rb
@@ -74,6 +74,10 @@ module Components
         render(default_template)
       end
 
+      def component_path
+        self.class == Components::Rails::Component ? attributes[:component] : self.class.component_path
+      end
+
       private
 
       def instrument_payload(key)
@@ -123,6 +127,10 @@ module Components
           name.demodulize.sub(/Component/, '').underscore
         end
 
+        def component_path
+          component_name.presence || 'application'
+        end
+
         protected
 
         def render_collection(action, view, collection, options)
@@ -156,10 +164,6 @@ module Components
         # Prefixes defined here will still be added to parents' <tt>._prefixes</tt>.
         def local_prefixes
           [component_path]
-        end
-
-        def component_path
-          component_name.presence || 'application'
         end
 
         def application_controller


### PR DESCRIPTION
Fixes #15 

This will update the caching support to look for the default action in the component path and generate a digest, if possible.

Note that actions may render views different than the default action name. In those cases, the default digest generator will not work.